### PR TITLE
fix: 예약자 관련 API 호출 변경

### DIFF
--- a/app/src/main/java/com/example/popmate/model/data/remote/reservation/MyReservationsResponse.kt
+++ b/app/src/main/java/com/example/popmate/model/data/remote/reservation/MyReservationsResponse.kt
@@ -6,6 +6,7 @@ data class MyReservationsResponse(
     val canceled: List<MyReservationResponse>? = null,
 ) {
     data class MyReservationResponse(
+        val userReservationId: Long,
         val bannerImgUrl: String,
         val endTime: String,
         val popupStoreId: Long,

--- a/app/src/main/java/com/example/popmate/model/data/remote/reservation/ReservationSuccessResponse.kt
+++ b/app/src/main/java/com/example/popmate/model/data/remote/reservation/ReservationSuccessResponse.kt
@@ -1,0 +1,5 @@
+package com.example.popmate.model.data.remote.reservation
+
+data class ReservationSuccessResponse(
+    val userReservationId: Long
+)

--- a/app/src/main/java/com/example/popmate/model/repository/service/reservation/ReservationApiService.kt
+++ b/app/src/main/java/com/example/popmate/model/repository/service/reservation/ReservationApiService.kt
@@ -5,6 +5,7 @@ import com.example.popmate.model.data.remote.ApiResponse
 import com.example.popmate.model.data.remote.reservation.CurrentReservationResponse
 import com.example.popmate.model.data.remote.reservation.MyReservationsResponse
 import com.example.popmate.model.data.remote.reservation.ReservationRequest
+import com.example.popmate.model.data.remote.reservation.ReservationSuccessResponse
 import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -29,17 +30,26 @@ interface ReservationApiService {
         @Path("userReservationId") userReservationId: Long
     ): Call<ApiResponse<MyReservationDetailResponse>>
 
+    /**
+     * 진행 중인 예약 조회
+     */
     @GET("popup-stores/{popupStoreId}/current-reservations")
     fun getCurrentReservation(
         @Path("popupStoreId") popupStoreId: Long
     ): Call<ApiResponse<CurrentReservationResponse>>
 
+    /**
+     * 선착순 예약
+     */
     @POST("reservations/{reservationId}")
     fun reserve(
         @Path("reservationId") reservationId: Long,
         @Body body: ReservationRequest
-    ): Call<ApiResponse<Void>>
+    ): Call<ApiResponse<ReservationSuccessResponse>>
 
+    /**
+     * 예약 취소
+     */
     @PATCH("user-reservations/{userReservationId}/cancel")
     fun cancelReservation(
         @Path("userReservationId") userReservationId: Long

--- a/app/src/main/java/com/example/popmate/model/repository/service/reservation/ReservationApiService.kt
+++ b/app/src/main/java/com/example/popmate/model/repository/service/reservation/ReservationApiService.kt
@@ -14,13 +14,19 @@ import retrofit2.http.Path
 
 interface ReservationApiService {
 
+    /**
+     * 나의 예약 목록 조회
+     */
     @GET("members/me/reservations")
     fun getMyReservations(
     ): Call<ApiResponse<MyReservationsResponse>>
 
-    @GET("members/me/reservations/{reservationId}")
+    /**
+     * 나의 예약 상세 조회
+     */
+    @GET("members/me/user-reservations/{userReservationId}")
     fun getMyReservation(
-        @Path("reservationId") reservationId: Long
+        @Path("userReservationId") userReservationId: Long
     ): Call<ApiResponse<MyReservationDetailResponse>>
 
     @GET("popup-stores/{popupStoreId}/current-reservations")

--- a/app/src/main/java/com/example/popmate/model/repository/service/reservation/ReservationApiService.kt
+++ b/app/src/main/java/com/example/popmate/model/repository/service/reservation/ReservationApiService.kt
@@ -40,8 +40,8 @@ interface ReservationApiService {
         @Body body: ReservationRequest
     ): Call<ApiResponse<Void>>
 
-    @PATCH("reservations/{reservationId}/cancel")
+    @PATCH("user-reservations/{userReservationId}/cancel")
     fun cancelReservation(
-        @Path("reservationId") reservationId: Long
+        @Path("userReservationId") userReservationId: Long
     ): Call<ApiResponse<Void>>
 }

--- a/app/src/main/java/com/example/popmate/view/activities/reservation/MyReservationDetailActivity.kt
+++ b/app/src/main/java/com/example/popmate/view/activities/reservation/MyReservationDetailActivity.kt
@@ -69,10 +69,9 @@ class MyReservationDetailActivity :
             // 예약 취소 다이얼로그 띄우기
             val dialog = ReservationCancelDialogFragment()
             val bundle = Bundle()
-            bundle.putLong("reservationId", viewModel.userReservationId)
+            bundle.putLong("userReservationId", viewModel.userReservationId)
             dialog.arguments = bundle
             dialog.show(supportFragmentManager, "ReservationCancelDialogFragment")
-//            viewModel.cancelReservation(viewModel.reservationId)
         }
     }
 

--- a/app/src/main/java/com/example/popmate/view/activities/reservation/MyReservationDetailActivity.kt
+++ b/app/src/main/java/com/example/popmate/view/activities/reservation/MyReservationDetailActivity.kt
@@ -35,12 +35,10 @@ class MyReservationDetailActivity :
     }
 
     private fun initView() {
-        viewModel.reservationId = intent.getLongExtra("reservationId", -1)
-        println("viewModel.reservationId = ${viewModel.reservationId}")
+        viewModel.userReservationId = intent.getLongExtra("userReservationId", -1)
 
-        viewModel.loadMyReservationDetail(viewModel.reservationId)
+        viewModel.loadMyReservationDetail(viewModel.userReservationId)
         viewModel.myReservation.observe(this) {
-            Log.d("smh", "initView: $it")
             binding.tvPopupStoreName.text = it.popupStoreTitle
             binding.tvVisitPeopleCount.text = it.guestCount.toString()
             binding.tvVisitLocation.text = it.popupStorePlaceDetail
@@ -71,7 +69,7 @@ class MyReservationDetailActivity :
             // 예약 취소 다이얼로그 띄우기
             val dialog = ReservationCancelDialogFragment()
             val bundle = Bundle()
-            bundle.putLong("reservationId", viewModel.reservationId)
+            bundle.putLong("reservationId", viewModel.userReservationId)
             dialog.arguments = bundle
             dialog.show(supportFragmentManager, "ReservationCancelDialogFragment")
 //            viewModel.cancelReservation(viewModel.reservationId)

--- a/app/src/main/java/com/example/popmate/view/activities/reservation/ReservationWaitActivity.kt
+++ b/app/src/main/java/com/example/popmate/view/activities/reservation/ReservationWaitActivity.kt
@@ -107,7 +107,8 @@ class ReservationWaitActivity :
     private fun showReservationSuccessDialog() {
         val dialog = ReservationSuccessDialogFragment()
         val bundle = Bundle()
-        bundle.putLong("reservationId", viewModel.reservationId!!) // 예약 성공 시 reservationId를 넘겨줌
+        bundle.putLong("userReservationId", viewModel.userReservationId!!)
+        bundle.putLong("reservationId", viewModel.reservationId!!)
         bundle.putLong("popupStoreId", viewModel.popupStoreId!!)
         dialog.arguments = bundle
         dialog.show(supportFragmentManager, "ReservationSuccessDialogFragment")

--- a/app/src/main/java/com/example/popmate/view/adapters/reservation/MyReservationAdapter.kt
+++ b/app/src/main/java/com/example/popmate/view/adapters/reservation/MyReservationAdapter.kt
@@ -30,11 +30,11 @@ class MyReservationAdapter(
              * 예약 상세 페이지로 이동
              */
             binding.layoutReservationDetail.setOnClickListener {
-                val selectedReservationId: Long = itemList[adapterPosition].reservationId
+                val selectedUserReservationId: Long = itemList[adapterPosition].userReservationId
                 val popupStoreId = Integer.parseInt(binding.tvId.text.toString())
                 val intent = Intent(context, MyReservationDetailActivity::class.java)
-                intent.putExtra("reservationId", selectedReservationId)
-                Log.d("MyReservationAdapter", "예약 상세 reservationId: $popupStoreId")
+                intent.putExtra("userReservationId", selectedUserReservationId)
+                Log.d("MyReservationAdapter", "예약 상세 userReservationId: $selectedUserReservationId")
                 context.startActivity(intent)
             }
 
@@ -42,7 +42,6 @@ class MyReservationAdapter(
              * 팝업 스토어 상세 페이지로 이동
              */
             binding.layoutPopupStore.setOnClickListener {
-                val popupStoreId = binding.tvId.text.toString().toLong()
                 val selectedPopupStoreId: Long = itemList[adapterPosition].popupStoreId
                 val intent = Intent(context, PopupDetailActivity::class.java)
                 intent.putExtra("id", selectedPopupStoreId)

--- a/app/src/main/java/com/example/popmate/view/fragments/ReservationCancelDialogFragment.kt
+++ b/app/src/main/java/com/example/popmate/view/fragments/ReservationCancelDialogFragment.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.graphics.Point
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -67,15 +68,15 @@ class ReservationCancelDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         viewModel = ViewModelProvider(this)[ReservationCancelViewModel::class.java]
-        viewModel.reservationId = arguments?.getLong("reservationId", 0) ?: 0
+        viewModel.userReservationId = arguments?.getLong("userReservationId", 0) ?: 0
 
         initEvent()
     }
 
     private fun initEvent() {
         binding.btnYes.setOnClickListener {
-            val reservationId = arguments?.getLong("reservationId", 0) ?: 0
-            viewModel.cancelReservation(reservationId)
+            val userReservationId = viewModel.userReservationId
+            viewModel.cancelReservation(userReservationId)
             dismiss()
             activity?.finish()
         }

--- a/app/src/main/java/com/example/popmate/view/fragments/ReservationSuccessDialogFragment.kt
+++ b/app/src/main/java/com/example/popmate/view/fragments/ReservationSuccessDialogFragment.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.graphics.Point
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -71,14 +72,15 @@ class ReservationSuccessDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         viewModel = ViewModelProvider(this)[ReservationSuccessViewModel::class.java]
-        viewModel.reservationId = arguments?.getLong("reservationId", 0) ?: 0
 
         initView()
         initEvent()
     }
 
     private fun initView() {
-        viewModel.getReservationInfo()
+        val userReservationId = arguments?.getLong("userReservationId", 0) ?: 0
+
+        viewModel.getReservationInfo(userReservationId)
         viewModel.myReservation.observe(viewLifecycleOwner) {
             if (it != null) {
                 binding.tvPopupStoreName.text = it.popupStoreTitle
@@ -93,7 +95,9 @@ class ReservationSuccessDialogFragment : DialogFragment() {
     private fun initEvent() {
         binding.btnClose.setOnClickListener {
             val intent = Intent(activity, MyReservationDetailActivity::class.java)
-            intent.putExtra("reservationId", viewModel.reservationId)
+            val reservationId = arguments?.getLong("reservationId", 0) ?: 0
+            intent.putExtra("reservationId", reservationId)
+            intent.putExtra("userReservationId", viewModel.userReservationId)
             startActivity(intent)
 
             // 다이얼로그, 액티비티 모두 종료

--- a/app/src/main/java/com/example/popmate/viewmodel/ReservationCancelViewModel.kt
+++ b/app/src/main/java/com/example/popmate/viewmodel/ReservationCancelViewModel.kt
@@ -14,10 +14,10 @@ import retrofit2.Response
 
 class ReservationCancelViewModel : BaseViewModel() {
 
-    var reservationId: Long = 0
+    var userReservationId: Long = 0
 
-    fun cancelReservation(reservationId: Long) {
-        ApiClient.reservationService.cancelReservation(reservationId)
+    fun cancelReservation(userReservationId: Long) {
+        ApiClient.reservationService.cancelReservation(userReservationId)
             .enqueue(object : Callback<ApiResponse<Void>> {
                 override fun onResponse(
                     call: Call<ApiResponse<Void>>,

--- a/app/src/main/java/com/example/popmate/viewmodel/ReservationSuccessViewModel.kt
+++ b/app/src/main/java/com/example/popmate/viewmodel/ReservationSuccessViewModel.kt
@@ -12,14 +12,22 @@ import retrofit2.Callback
 import retrofit2.Response
 
 class ReservationSuccessViewModel : ViewModel() {
-    var reservationId: Long = 0
+
+    private var _reservationId: Long? = null
+    val reservationId: Long?
+        get() = _reservationId
+
+    private var _userReservationId: Long? = null
+    val userReservationId: Long?
+        get() = _userReservationId
 
     private val _myReservation = MutableLiveData<MyReservationDetailResponse>()
     val myReservation: LiveData<MyReservationDetailResponse> = _myReservation
 
-    fun getReservationInfo() {
-        Log.i("ReservationSuccessViewModel", "getReservationInfo: $reservationId")
-        ApiClient.reservationService.getMyReservation(reservationId)
+    fun getReservationInfo(userReservationId: Long) {
+        _userReservationId = userReservationId
+        Log.i("smh", "getReservationInfo: $userReservationId")
+        ApiClient.reservationService.getMyReservation(userReservationId)
             .enqueue(object : Callback<ApiResponse<MyReservationDetailResponse>> {
                 override fun onResponse(
                     call: Call<ApiResponse<MyReservationDetailResponse>>,

--- a/app/src/main/java/com/example/popmate/viewmodel/reservation/MyReservationDetailViewModel.kt
+++ b/app/src/main/java/com/example/popmate/viewmodel/reservation/MyReservationDetailViewModel.kt
@@ -12,7 +12,7 @@ import retrofit2.Callback
 import retrofit2.Response
 
 class MyReservationDetailViewModel : BaseViewModel() {
-    var reservationId: Long = 0
+    var userReservationId: Long = 0
 
     private val _myReservation = MutableLiveData<MyReservationDetailResponse>()
     val myReservation: LiveData<MyReservationDetailResponse> = _myReservation


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## Linked Issues
- Resolve: #141

<!-- ✅ 변경 사항을 자세히 알려주세요. -->
## Change Details
- 변경된 API 스펙에 맞춰 예약자 관련 API를 모두 변경해주었습니다.
- 해당 이슈 참고 부탁드립니다.

<!-- ✅ 추가로 전달할 내용이 있다면 적어주세요. -->
## Comment
개선된 부분은 다음과 같습니다.
- 마이페이지 예약 상태 별로 조회 가능하도록 수정
- 예약을 취소하고 다시 예약한 경우에 조회 안되는 버그 수정

<!-- ✅ 참고한 사이트가 있다면 공유해주세요. -->
## References
- [백엔드 이슈 참고](https://github.com/bone-stew/popmate-be/pull/195)

## ✔ Check List

- [x] 코드 포매팅은 확인하셨나요?
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
